### PR TITLE
Convert any data to be posted to buffer api to utf-8 encoding.

### DIFF
--- a/buffpy/api.py
+++ b/buffpy/api.py
@@ -54,6 +54,11 @@ class API(object):
 
     headers = {'Content-Type': 'application/x-www-form-urlencoded'}
 
+    #Check if posting data and if data is unicode, encoding it as utf-8
+    if 'data' in params and isinstance(params['data'], unicode):
+      params['data'] = params['data'].encode('utf-8')
+
+
     response = self.session.post(url=BASE_URL % url, headers=headers, **params)
 
     return parser(response.content)


### PR DESCRIPTION
By default ascii encoding is used while creating/updating tweets. Hence trying to create an update with unicode characters gives an exception 'UnicodeDecodeError'. By encoding any data  that is sent to the buffer api to utf-8, you can now also send text containing unicode characters without any issue.